### PR TITLE
Fix PHP warning

### DIFF
--- a/library/BeiderMorse.php
+++ b/library/BeiderMorse.php
@@ -318,7 +318,7 @@ class BeiderMorse extends Core
             $list  = ['da', 'dal', 'de', 'del', 'dela', 'de la', 'della', 'des', 'di', 'do', 'dos', 'du', 'van', 'von'];
             $clist = count($list);
 
-            for( $j = 0; $j < count($clist); $j++ ) {
+            for( $j = 0; $j < $clist; $j++ ) {
 
                 $prefix       = "$list[$j] ";
                 $prefixLength = strlen($prefix);


### PR DESCRIPTION
Fixing the following PHP warning (tested on PHP 7.2)

```
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /Projects/test-test-test/vendor/nmapx/bmdm-soundex/library/BeiderMorse.php on line 321
```